### PR TITLE
NativeEventEmitter: fix once() implementation

### DIFF
--- a/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/Libraries/EventEmitter/NativeEventEmitter.js
@@ -41,6 +41,18 @@ class NativeEventEmitter extends EventEmitter {
     return super.addListener(eventType, listener, context);
   }
 
+  once(eventType: string, listener: Function, context: ?Object): EmitterSubscription {
+    const subscription = this.addListener(
+      eventType, 
+      function(data: ?Object) {
+        subscription.remove();
+        listener(data);
+      }, 
+      contest
+    );
+    return subscription;
+  }
+
   removeAllListeners(eventType: string) {
     invariant(eventType, 'eventType argument is required.');
     if (Platform.OS === 'ios') {


### PR DESCRIPTION
Default EventEmitter `once()` uses `removeCurrentListener()` which only works when executed in the same tick as `emit()` fn. 
In the case of iOS events are actually triggered by the nativeModule which does not use `emit()` fn, therefore it throws.

My implementation leverages on the EmitterSubscription to make it work in all cases

I am not sure how to write tests for this yet. Where should i look ?